### PR TITLE
Fix for Issue #3 blacklist.sh

### DIFF
--- a/blacklist.sh
+++ b/blacklist.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
+echo "Blacklist update started" > /config/scripts/blacklist-processing.txt ; 
+date >> /config/scripts/blacklist-processing.txt ;
 
-real_list=`grep -B1 "Dynamic Threat List" /config/config.boot | head -n 1 | awk '{print $2}'`
-[[ -z "$real_list" ]] && { echo "aborting"; exit -1; } || echo "Updating $real_list"
+real_list=$(grep -B1 "Dynamic Threat List" /config/config.boot | head -n 1 | awk '{print $2}'); [[ -z "$real_list" ]] && { echo "aborting"; exit 1; } || echo "Updating $real_list";
 
-ipset_list='temporary-list'
+ipset_list='temporary-list' ;
 
-sudo /sbin/ipset -! destroy $ipset_list
-sudo /sbin/ipset create $ipset_list hash:net
+sudo /sbin/ipset -! destroy $ipset_list ;
+sudo /sbin/ipset create $ipset_list hash:net ;
 
-for url in 'https://www.spamhaus.org/drop/edrop.txt' 'http://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt' 'https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1';
-do
- echo "Fetching and processing $url"
- curl "$url" | awk '/^[1-9]/ { print $1 }' | xargs -n1 sudo ipset -q add $ipset_list
-done
+for url in https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level2.netset https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level3.netset https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_webclient.netset
+do echo "Fetching and processing $url" ;
+ { echo "Processing blacklist" ; 
+  date ; 
+  echo $url ;
+ } >> /config/scripts/blacklist-processing.txt ;
+ curl "$url" | awk '/^[1-9]/ { print $1 }' | xargs -n1 sudo ipset -exist add $ipset_list ;
+done ;
 
-sudo /sbin/ipset swap $ipset_list $real_list
-sudo /sbin/ipset destroy $ipset_list
+sudo /sbin/ipset swap $ipset_list "$real_list" ;
+
+{ echo "Blacklist update finished" ; 
+ date ; 
+ echo "Blacklist contents" ; 
+ sudo /sbin/ipset list -s "$real_list" ;
+ } >> /config/scripts/blacklist-processing.txt ;
+ 
+sudo /sbin/ipset destroy $ipset_list ;


### PR DESCRIPTION
The fix for the syntax error for the blacklist.sh file is putting the do and echo "Fetching....." commands on the same line.  While what you have is syntax correct according to https://www.shellcheck.net/ it is not interrupted correctly by the USG CLI when they are on separate lines.  I added some logging of this script into a text file /config/scripts/blacklist-processing.txt so this will let the user know that yes the script is running and here's what it has done.  It logs the start of the process, the URLs processed, the final list contents, as well as the time each step was ran.  I also updated the rest of the code to be written in best practice according to https://www.shellcheck.net/.  I ran into the same issue with my { echo "Processing....." section of code, where if the { and echo are on separate lines the USG failed the script with a syntax error even though it is syntax correct according to https://www.shellcheck.net/, so they had to be put on the same line to make the USG CLI interrupt the code correctly.

You can also see I've updated your URLs to use FireHOL.  These people are great and the lists I've included from them are aggregates of the lists you were already using plus many more.  You can check them out here https://github.com/firehol/blocklist-ipsets, http://iplists.firehol.org/, https://firehol.org/.